### PR TITLE
Add column confirmed to bookings table

### DIFF
--- a/db/migrate/20220823145242_add_confirmed_to_bookings.rb
+++ b/db/migrate/20220823145242_add_confirmed_to_bookings.rb
@@ -1,0 +1,5 @@
+class AddConfirmedToBookings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bookings, :confirmed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_22_103215) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_23_145242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,6 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_22_103215) do
     t.date "end_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "confirmed", default: false
     t.index ["bicycle_id"], name: "index_bookings_on_bicycle_id"
     t.index ["user_id"], name: "index_bookings_on_user_id"
   end


### PR DESCRIPTION
Add column confirmed to bookings table

value defaults to false and will become true when a bicycle owner confirms the booking on their dashboard