### PR TITLE
Update navbar to centralise search & place login on right

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,6 +1,17 @@
-.navbar {
-  background-color: $background-colour_green;
-  position: sticky;
-  top: 0;
-  z-index: 2;
+// .navbar {
+  // }
+
+  .navbar {
+    background-color: $background-colour_green;
+    justify-content: space-between;
+    position: sticky;
+    top: 0;
+}
+
+.navbar .navbar-collapse {
+  flex-grow: 0;
+}
+
+.navbar .navbar-brand img {
+  width: 40px;
 }

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,44 +1,41 @@
-<nav class="navbar navbar-expand-lg">
+<div class="navbar navbar-expand-sm navbar-light navbar">
   <div class="container-fluid">
-    <%= link_to root_path, class: "navbar-brand" do %>
-      <i class="fa-solid fa-bicycle fs-2"></i>
+     <%= link_to root_path, class: "navbar-brand" do %>
+      <i class="fa-solid fa-bicycle fs-3"></i>
     <% end %>
 
+    <form class="d-flex">
+        <input class="form-control me-2" type="search" placeholder="Find a Bicycle" aria-label="Search">
+        <button class="btn btn-success text-muted" type="submit">Search</button>
+    </form>
+
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-      <i class="fa-solid fa-bars fs-2"></i>
+      <span class="navbar-toggler-icon"></span>
     </button>
 
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+      <ul class="navbar-nav me-auto">
+        <% if user_signed_in? %>
+          <li class="nav-item active">
+            <%= link_to "Home", root_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
 
-      <% if user_signed_in? %>
-        <li class="nav-item active">
-          <%= link_to "Home", root_path, class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Browse Bicycles</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-            More
-          </a>
-          <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <li><a class="dropdown-item" href="#">Bookings</a></li>
-            <li><a class="dropdown-item" href="#">Account</a></li>
-            <li><hr class="dropdown-divider"></li>
-            <li><%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %></li>
-          </ul>
-        </li>
+          </li>
+          <li class="nav-item dropdown">
+            <i class="fa-solid fa-bars fs-4 nav-link" id="navbarDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></i>
+            <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+              <%= link_to "Browse Bicycles", bicycles_path, class: "dropdown-item" %>
+              <%= link_to "My Bookings", "#", class: "dropdown-item" %>
+              <%= link_to "Log out", destroy_user_session_path, class: "dropdown-item", data: {turbo_method: :delete} %>
+            </div>
+          </li>
         <% else %>
           <li class="nav-item">
             <%= link_to "Login", new_user_session_path, class: "nav-link" %>
           </li>
         <% end %>
       </ul>
-      <form class="d-flex">
-        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-        <button class="btn btn-success text-muted" type="submit">Find a bicycle</button>
-      </form>
     </div>
   </div>
-</nav>
+</div>


### PR DESCRIPTION
Replaces the old navbar (based on a bootstrap navbar component) with one based on nav component from the wagon ui kit.

This was done to be able to center the search form element in the navbar and put the login / menu button on the right of navbar